### PR TITLE
Recognize the name that bat is run as.

### DIFF
--- a/src/pager.rs
+++ b/src/pager.rs
@@ -40,16 +40,24 @@ impl PagerKind {
     fn from_bin(bin: &str) -> PagerKind {
         use std::path::Path;
 
-        match Path::new(bin)
-            .file_stem()
-            .map(|s| s.to_string_lossy())
-            .as_deref()
-        {
+        let file_stem = Path::new(bin).file_stem();
+
+        match file_stem.map(|s| s.to_string_lossy()).as_deref() {
             Some("bat") => PagerKind::Bat,
             Some("less") => PagerKind::Less,
             Some("more") => PagerKind::More,
             Some("most") => PagerKind::Most,
-            _ => PagerKind::Unknown,
+            _ => {
+                if env::args_os()
+                    .nth(0)
+                    .map(|arg0| Path::new(&arg0).file_stem() == file_stem)
+                    .unwrap_or(false)
+                {
+                    PagerKind::Bat
+                } else {
+                    PagerKind::Unknown
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Some distributions such as Debian package bat under a different name (such as batcat) to prevent collisions. Extend the logic that is used to identify itself to prevent infinite recursion by automatically recognizing the name that bat is run as.